### PR TITLE
point to main version explicitly

### DIFF
--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -31,3 +31,4 @@ galaxy_info:
 dependencies:
   - name: add_prometheus_target
     src: https://github.com/redhat-performance/ansible-role-add_prometheus_target
+    version: main


### PR DESCRIPTION
although `main` is the default branch, ansible-galaxy is looking at `master` by default